### PR TITLE
fix app not building

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,3 @@
-import { useFocusEffect, useNavigation, useRouter } from 'expo-router';
-import TopHeader from '~/components/TopHeader';
 import { useFocusEffect, useNavigation } from 'expo-router';
 import { LogBox } from 'react-native';
 import { NativeStackNavigationProp } from 'react-native-screens/lib/typescript/native-stack/types';


### PR DESCRIPTION
Apka się nie odpalała bo importy z 'expo-router' były dwa razy zdefiniowane