### PR TITLE
dismiss keyboard after entering menu from header

### DIFF
--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -2,7 +2,7 @@ import { FontAwesome5 } from '@expo/vector-icons';
 import { DrawerActions } from '@react-navigation/native';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, Keyboard } from 'react-native';
 
 import MenuIcon from '../../assets/menus1.svg';
 import NavigationIcon from '../../assets/navigation.svg';
@@ -25,7 +25,10 @@ export default function TopHeader({ onlyBack, modeSearch, toggleSearchBar }: Top
         className="absolute left-0 right-0 top-0 z-20 h-28 flex-row items-center justify-between bg-green-main px-4 pb-0 pt-8">
         <TouchableOpacity
           className="p-2"
-          onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}>
+          onPress={() => {
+            Keyboard.dismiss();
+            navigation.dispatch(DrawerActions.toggleDrawer());
+          }}>
           <MenuIcon width={40} height={40} fill="#FFF" />
         </TouchableOpacity>
         <Text className="text-2xl font-bold text-white">Nawigacja SGGW </Text>


### PR DESCRIPTION
dismissing keyboard after entering menu from header in order to avoid unnecessary front end bugs